### PR TITLE
fix(merge): adjust behaviour of rust merge function to the ts one

### DIFF
--- a/live-backend/src/data/merge.rs
+++ b/live-backend/src/data/merge.rs
@@ -12,9 +12,13 @@ pub fn merge(base: &mut Value, update: Value) {
         }
         (Value::Array(ref mut prev), Value::Object(update)) => {
             for (k, v) in update {
-                k.parse::<usize>()
-                    .ok()
-                    .and_then(|index| prev.get_mut(index).map(|item| merge(item, v)));
+                if let Some(index) = k.parse::<usize>().ok() {
+                    if let Some(item) = prev.get_mut(index) {
+                        merge(item, v);
+                    } else {
+                        prev.push(v);
+                    }
+                }
             }
         }
         (a, b) => *a = b,


### PR DESCRIPTION
this is expected to fix #103 
where data would not be merged correctly in the backend and so frontend and backend will get de-synced and dataloss happens on reload.