### PR TITLE
feature/map-corner-numbers

### DIFF
--- a/dash/src/app/(nav)/settings/page.tsx
+++ b/dash/src/app/(nav)/settings/page.tsx
@@ -17,6 +17,7 @@ export default function SettingsPage() {
 	const [tableHeaders, setTableHeaders] = useState<boolean>(false);
 	const [sectorFastest, setSectorFastest] = useState<boolean>(false);
 	const [carMetrics, setCarMetrics] = useState<boolean>(false);
+	const [showCornerNumbers, setShowCornerNumbers] = useState<boolean>(false);
 
 	const [delay, setDelay] = useState<number>(0);
 
@@ -33,10 +34,11 @@ export default function SettingsPage() {
 			setTableHeaders(customSettings.tableHeaders);
 			setSectorFastest(customSettings.sectorFastest);
 			setCarMetrics(customSettings.carMetrics);
+			setShowCornerNumbers(customSettings.showCornerNumbers);
 		}
 	}, []);
 
-	const handleUpdate = (type: "sector" | "table" | "car", newValue: boolean) => {
+	const handleUpdate = (type: "sector" | "table" | "car" | "corner", newValue: boolean) => {
 		if (typeof window != undefined) {
 			const customStorage = localStorage.getItem("custom");
 			const customSettings: UiElements = customStorage ? JSON.parse(customStorage) : modes.custom;
@@ -52,6 +54,10 @@ export default function SettingsPage() {
 				}
 				case "sector": {
 					customSettings.sectorFastest = newValue;
+					break;
+				}
+				case "corner": {
+					customSettings.showCornerNumbers = newValue;
 					break;
 				}
 			}
@@ -118,6 +124,17 @@ export default function SettingsPage() {
 					}}
 				/>
 				<p className="text-zinc-500">Show Car Metrics (RPM, Gear, Speed)</p>
+			</div>
+
+			<div className="flex gap-2">
+				<Toggle
+					enabled={showCornerNumbers}
+					setEnabled={(v) => {
+						setShowCornerNumbers(v);
+						handleUpdate("corner", v);
+					}}
+				/>
+				<p className="text-zinc-500">Show Corner Numbers on Track Map</p>
 			</div>
 
 			<h2 className="my-4 text-2xl">Delay</h2>

--- a/dash/src/components/Map.tsx
+++ b/dash/src/components/Map.tsx
@@ -317,7 +317,7 @@ export default function Map({
 			{uiElements.showCornerNumbers &&
 				corners.map((corner) => (
 					<CornerNumber
-						key={`corner-${corner.number}`}
+						key={`corner.${corner.number}`}
 						number={corner.number}
 						x={corner.labelPos.x}
 						y={corner.labelPos.y}

--- a/dash/src/context/ModeContext.tsx
+++ b/dash/src/context/ModeContext.tsx
@@ -14,6 +14,7 @@ export type UiElements = {
 	tableHeaders: boolean;
 	sectorFastest: boolean;
 	carMetrics: boolean;
+	showCornerNumbers: boolean;
 };
 
 type Mode = "simple" | "advanced" | "expert" | "custom";
@@ -27,22 +28,26 @@ export const modes: Modes = {
 		tableHeaders: false,
 		sectorFastest: false,
 		carMetrics: false,
+		showCornerNumbers: false,
 	},
 	advanced: {
 		tableHeaders: true,
 		sectorFastest: true,
 		carMetrics: false,
+		showCornerNumbers: true,
 	},
 	expert: {
 		tableHeaders: false,
 		sectorFastest: false,
 		carMetrics: true,
+		showCornerNumbers: true,
 	},
 	// custom is used as default values
 	custom: {
 		tableHeaders: false,
 		sectorFastest: false,
 		carMetrics: false,
+		showCornerNumbers: false,
 	},
 };
 


### PR DESCRIPTION
feat: show corner numbers on track map
- Built corner numbers into the track map in a similar way to tdjsnelling/monaco.
- Added a new setting in the settings menu to toggle corner numbers.
- Added the corner numbers into the context manager for the different dashboard modes. 
