### PR TITLE
bugfix/driver-best-sectors-color

### DIFF
--- a/dash/src/components/driver/DriverMiniSectors.tsx
+++ b/dash/src/components/driver/DriverMiniSectors.tsx
@@ -34,7 +34,7 @@ export default function DriverMiniSectors({ sectors = [], bestSectors, tla, show
 						</p>
 
 						{showFastest && (
-							<p className={clsx("text-sm font-semibold leading-none text-violet-600")}>
+							<p className={clsx("text-sm font-semibold leading-none text-emerald-500")}>
 								{bestSectors && bestSectors[i].value ? bestSectors[i].value : "-- ---"}
 							</p>
 						)}


### PR DESCRIPTION
Partially fixes #139 
At least uses more correct colors there's no dater to find out if the personal best sectors are the fastest, I only have if the driver has the fastest lap and not which sectors.