### PR TITLE
patch 2.5.3

### DIFF
--- a/dash/dockerfile
+++ b/dash/dockerfile
@@ -1,12 +1,15 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS dependencies
 
 WORKDIR /app
 COPY package*.json ./
 COPY yarn.lock ./
+COPY .yarnrc.yml ./
 
-RUN yarn install --frozen-lockfile
+RUN corepack enable
 
-FROM base as builder
+RUN yarn install --immutable
+
+FROM dependencies AS builder
 
 ARG NODE_ENV
 ARG NEXT_PUBLIC_ENABLE_TRACKING
@@ -26,10 +29,11 @@ COPY . .
 
 RUN yarn build
 
-FROM node:20-alpine AS runtime
+FROM node:22-alpine AS runtime
 
 WORKDIR /app
 
+COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 

--- a/dash/package.json
+++ b/dash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "f1-dash",
-	"version": "2.5.2",
+	"version": "2.5.3",
 	"private": true,
 	"scripts": {
 		"build": "next build",

--- a/dash/src/components/TeamRadios.tsx
+++ b/dash/src/components/TeamRadios.tsx
@@ -44,7 +44,7 @@ const SkeletonMessage = () => {
 	const animateClass = "h-6 animate-pulse rounded-md bg-zinc-800";
 
 	return (
-		<li className="flex flex-col gap-1">
+		<li className="flex flex-col gap-1 p-2">
 			<div className={clsx(animateClass, "!h-4 w-16")} />
 
 			<div

--- a/dockerfile
+++ b/dockerfile
@@ -8,10 +8,10 @@ RUN apk add --no-cache musl-dev pkgconfig openssl libressl-dev
 # only builds default members (live and api)
 RUN cargo b -r
 
-FROM alpine:3 as api
+FROM alpine:3 AS api
 COPY --from=builder /usr/src/app/target/release/api /api
 CMD [ "/api" ]
 
-FROM alpine:3 as live
+FROM alpine:3 AS live
 COPY --from=builder /usr/src/app/target/release/live /live
 CMD [ "/live" ]


### PR DESCRIPTION
definitely fixes #208 
fixes frontend docker image not having static public folder in runner step causing images to not be found
adds usage of corepack to dashboard docker image
update to node 22 in dashboard docker image
fixes missing padding in team radio loading skeleton