### PR TITLE
feature/tooltips

### DIFF
--- a/dash/package.json
+++ b/dash/package.json
@@ -20,6 +20,7 @@
 		"pako": "2.1.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
+		"react-tooltip": "^5.28.0",
 		"sharp": "0.33.5",
 		"zod": "3.23.8",
 		"zustand": "5.0.1"

--- a/dash/src/app/(nav)/settings/page.tsx
+++ b/dash/src/app/(nav)/settings/page.tsx
@@ -56,6 +56,11 @@ export default function SettingsPage() {
 			</div>
 
 			<div className="flex gap-2">
+				<Toggle enabled={settings.showTooltips} setEnabled={(v) => settings.setShowTooltips(v)} />
+				<p className="text-zinc-500">Show Tooltips</p>
+			</div>
+
+			<div className="flex gap-2">
 				<Toggle enabled={settings.raceControlChime} setEnabled={(v) => settings.setRaceControlChime(v)} />
 				<p className="text-zinc-500">Play Race Control Chime</p>
 			</div>

--- a/dash/src/app/(nav)/settings/page.tsx
+++ b/dash/src/app/(nav)/settings/page.tsx
@@ -153,7 +153,7 @@ const FavoriteDrivers = () => {
 
 					return (
 						<div key={driverNumber} className="flex items-center gap-1 rounded-xl border border-zinc-700 p-1">
-							<DriverTag teamColor={driver.teamColour} short={driver.tla} />
+							<DriverTag driver={driver} />
 
 							<motion.button
 								whileHover={{ scale: 1.05 }}

--- a/dash/src/app/dashboard/page.tsx
+++ b/dash/src/app/dashboard/page.tsx
@@ -4,8 +4,10 @@ import { useEffect, useRef } from "react";
 import clsx from "clsx";
 
 import Fireworks, { FireworksHandlers } from "@fireworks-js/react";
+import { Tooltip } from "react-tooltip";
 
 import { useDataStore } from "@/stores/useDataStore";
+import { useSettingsStore } from "@/stores/useSettingsStore";
 
 import SessionInfo from "@/components/SessionInfo";
 import WeatherInfo from "@/components/WeatherInfo";
@@ -25,6 +27,7 @@ export default function Page() {
 	const sessionType = useDataStore((state) => state.sessionInfo?.type);
 
 	const raceControlMessages = useDataStore((state) => state.raceControlMessages?.messages);
+	const showTooltips = useSettingsStore((state) => state.showTooltips);
 
 	useEffect(() => {
 		if (sessionType === "Race") {
@@ -145,6 +148,7 @@ export default function Page() {
 					background: "#00000000",
 				}}
 			/>
+			{showTooltips && <Tooltip id="tooltip" />}
 		</div>
 	);
 }

--- a/dash/src/app/layout.tsx
+++ b/dash/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import Script from "next/script";
 
 import "@/styles/globals.css";
+import "react-tooltip/dist/react-tooltip.css";
 
 import { env } from "@/env.mjs";
 

--- a/dash/src/components/ConnectionStatus.tsx
+++ b/dash/src/components/ConnectionStatus.tsx
@@ -7,5 +7,11 @@ type Props = {
 };
 
 export default function ConnectionStatus({ connected }: Props) {
-	return <div className={clsx("size-3 rounded-full", connected ? "bg-emerald-500" : "animate-pulse bg-red-500")} />;
+	return (
+		<div
+			className={clsx("size-3 rounded-full", connected ? "bg-emerald-500" : "animate-pulse bg-red-500")}
+			data-tooltip-id="tooltip"
+			data-tooltip-content={connected ? "Connected" : "Reconnecting..."}
+		/>
+	);
 }

--- a/dash/src/components/DelayInput.tsx
+++ b/dash/src/components/DelayInput.tsx
@@ -29,6 +29,8 @@ export default function DelayInput({ className }: Props) {
 			placeholder="0s"
 			value={currentDelay}
 			onChange={(e) => handleChange(e.target.value)}
+			data-tooltip-id="tooltip"
+			data-tooltip-content="Delay (seconds)"
 		/>
 	);
 }

--- a/dash/src/components/QualifyingDriver.tsx
+++ b/dash/src/components/QualifyingDriver.tsx
@@ -49,7 +49,7 @@ export default function DriverQuali({
 			initial={{ opacity: 0 }}
 		>
 			<div className="flex justify-between">
-				<DriverTag position={parseInt(timingDriver.position)} teamColor={driver.teamColour} short={driver.tla} />
+				<DriverTag position={parseInt(timingDriver.position)} driver={driver} />
 				<div>
 					{currentStint && !unknownCompound && currentStint.compound && (
 						<Image

--- a/dash/src/components/TeamRadioMessage.tsx
+++ b/dash/src/components/TeamRadioMessage.tsx
@@ -90,7 +90,7 @@ export default function TeamRadioMessage({ driver, capture, basePath }: Props) {
 				}}
 			>
 				<div className="w-10 place-self-start">
-					<DriverTag teamColor={driver.teamColour} short={driver.tla} />
+					<DriverTag driver={driver} />
 				</div>
 
 				<div className="flex items-center gap-1">

--- a/dash/src/components/TrackViolationsDriver.tsx
+++ b/dash/src/components/TrackViolationsDriver.tsx
@@ -17,7 +17,7 @@ type Props = {
 export default function TrackViolationsDriver({ driver, driverViolations, driversTiming }: Props) {
 	return (
 		<div className="flex gap-2" key={`violation.${driver.racingNumber}`}>
-			<DriverTag className="h-fit" teamColor={driver.teamColour} short={driver.tla} />
+			<DriverTag className="h-fit" driver={driver} />
 			<div className="flex items-center gap-2">
 				{new Array(driverViolations).fill("").map((_, i) => (
 					<Image src={octagonX} className="size-6" alt="x in octagon" />

--- a/dash/src/components/complications/Humidity.tsx
+++ b/dash/src/components/complications/Humidity.tsx
@@ -10,7 +10,11 @@ type Props = {
 
 export default function HumidityComplication({ value }: Props) {
 	return (
-		<div className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black">
+		<div
+			className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black"
+			data-tooltip-id="tooltip"
+			data-tooltip-content="Humidity %"
+		>
 			<Gauge value={value} max={100} gradient="humidity" />
 
 			<div className="mt-2 flex flex-col items-center gap-0.5">

--- a/dash/src/components/complications/Rain.tsx
+++ b/dash/src/components/complications/Rain.tsx
@@ -9,7 +9,11 @@ type Props = {
 
 export default function RainComplication({ rain }: Props) {
 	return (
-		<div className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black">
+		<div
+			className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black"
+			data-tooltip-id="tooltip"
+			data-tooltip-content={rain ? "Rain" : "No Rain"}
+		>
 			{rain ? (
 				<Image src={rainIcon} alt="rain" className="h-[25px] w-auto" />
 			) : (

--- a/dash/src/components/complications/Temperature.tsx
+++ b/dash/src/components/complications/Temperature.tsx
@@ -7,7 +7,11 @@ type Props = {
 
 export default function TemperatureComplication({ value, label }: Props) {
 	return (
-		<div className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black">
+		<div
+			className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black"
+			data-tooltip-id="tooltip"
+			data-tooltip-content={label === "TRC" ? "Track Temp" : "Air Temp"}
+		>
 			<Gauge value={value} max={label === "TRC" ? 60 : 40} gradient="temperature" />
 
 			<div className="mt-2 flex flex-col items-center gap-0.5">

--- a/dash/src/components/complications/WindSpeed.tsx
+++ b/dash/src/components/complications/WindSpeed.tsx
@@ -7,7 +7,11 @@ type Props = {
 
 export default function WindSpeedComplication({ speed, directionDeg }: Props) {
 	return (
-		<div className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black">
+		<div
+			className="flex h-[55px] w-[55px] items-center justify-center rounded-full bg-black"
+			data-tooltip-id="tooltip"
+			data-tooltip-content="Wind"
+		>
 			<div className="flex flex-col items-center">
 				<p className="text-center text-[10px] font-medium leading-none text-blue-400">
 					{getWindDirection(directionDeg)}

--- a/dash/src/components/driver/Driver.tsx
+++ b/dash/src/components/driver/Driver.tsx
@@ -27,7 +27,10 @@ const hasDRS = (drs: number) => drs > 9;
 
 const possibleDRS = (drs: number) => drs === 8;
 
-const inDangerZone = (position: number, sessionPart: number) => {
+const inDangerZone = (position: number, sessionPart?: number) => {
+	if (sessionPart == null) {
+		return false;
+	}
 	switch (sessionPart) {
 		case 1:
 			return position > 15;
@@ -53,6 +56,21 @@ export default function Driver({ driver, timingDriver, position }: Props) {
 
 	const favoriteDriver = useSettingsStore((state) => state.favoriteDrivers.includes(driver.racingNumber));
 
+	let statusTooltip = undefined;
+	if (timingDriver.knockedOut) {
+		statusTooltip = "Knocked out";
+	} else if (timingDriver.retired) {
+		statusTooltip = "Retired";
+	} else if (timingDriver.stopped) {
+		statusTooltip = "Stopped";
+	} else if (hasFastest) {
+		statusTooltip = "Fastest Lap";
+	} else if (favoriteDriver) {
+		statusTooltip = "Favorite Driver";
+	} else if (inDangerZone(position, sessionPart)) {
+		statusTooltip = "In Danger Zone";
+	}
+
 	return (
 		<motion.div
 			layout="position"
@@ -60,7 +78,7 @@ export default function Driver({ driver, timingDriver, position }: Props) {
 				"opacity-50": timingDriver.knockedOut || timingDriver.retired || timingDriver.stopped,
 				"bg-sky-800 bg-opacity-30": favoriteDriver,
 				"bg-violet-800 bg-opacity-30": hasFastest,
-				"bg-red-800 bg-opacity-30": sessionPart != undefined && inDangerZone(position, sessionPart),
+				"bg-red-800 bg-opacity-30": inDangerZone(position, sessionPart),
 			})}
 		>
 			<div
@@ -71,7 +89,7 @@ export default function Driver({ driver, timingDriver, position }: Props) {
 						: "5.5rem 4rem 5.5rem 4rem 5rem 5.5rem auto",
 				}}
 			>
-				<DriverTag className="!min-w-full" short={driver.tla} teamColor={driver.teamColour} position={position} />
+				<DriverTag className="!min-w-full" driver={driver} position={position} statusTooltip={statusTooltip} />
 				<DriverDRS
 					on={carData ? hasDRS(carData[45]) : false}
 					possible={carData ? possibleDRS(carData[45]) : false}

--- a/dash/src/components/driver/DriverCarMetrics.tsx
+++ b/dash/src/components/driver/DriverCarMetrics.tsx
@@ -17,9 +17,15 @@ export default function DriverCarMetrics({ carData }: Props) {
 
 	return (
 		<div className="flex items-center gap-2 place-self-start">
-			<p className="flex h-8 w-8 items-center justify-center font-mono text-lg">{carData[3]}</p>
+			<p
+				className="flex h-8 w-8 items-center justify-center font-mono text-lg"
+				data-tooltip-id="tooltip"
+				data-tooltip-content="Gear"
+			>
+				{carData[3]}
+			</p>
 
-			<div>
+			<div data-tooltip-id="tooltip" data-tooltip-content="Speed">
 				<p className="text-right font-mono font-medium leading-none">
 					{speedUnit === "metric" ? carData[2] : convertKmhToMph(carData[2])}
 				</p>
@@ -28,9 +34,9 @@ export default function DriverCarMetrics({ carData }: Props) {
 
 			<div className="flex flex-col">
 				<div className="flex flex-col gap-1">
-					<DriverPedals className="bg-red-500" value={carData[5]} maxValue={1} />
-					<DriverPedals className="bg-emerald-500" value={carData[4]} maxValue={100} />
-					<DriverPedals className="bg-blue-500" value={carData[0]} maxValue={15000} />
+					<DriverPedals className="bg-red-500" value={carData[5]} maxValue={1} tooltip="Brake" />
+					<DriverPedals className="bg-emerald-500" value={carData[4]} maxValue={100} tooltip="Throttle" />
+					<DriverPedals className="bg-blue-500" value={carData[0]} maxValue={15000} tooltip="RPM" />
 				</div>
 			</div>
 		</div>

--- a/dash/src/components/driver/DriverDRS.tsx
+++ b/dash/src/components/driver/DriverDRS.tsx
@@ -10,18 +10,34 @@ type Props = {
 export default function DriverDRS({ on, possible, inPit, pitOut }: Props) {
 	const pit = inPit || pitOut;
 
+	let tooltip = null;
+	let colors = null;
+	if (inPit) {
+		tooltip = "In Pit Lane";
+		colors = "border-cyan-500 text-cyan-500";
+	} else if (pitOut) {
+		tooltip = "Leaving Pit Lane";
+		colors = "border-cyan-500 text-cyan-500";
+	} else if (on) {
+		tooltip = "DRS is active";
+		colors = "border-emerald-500 text-emerald-500";
+	} else if (possible) {
+		tooltip = "Possible: got DRS in next zone";
+		colors = "border-zinc-400 text-zinc-400";
+	} else {
+		tooltip = "No DRS";
+		colors = "border-zinc-700 text-zinc-700";
+	}
+
 	return (
 		<span
 			id="walkthrough-driver-drs"
 			className={clsx(
 				"text-md inline-flex h-8 w-full items-center justify-center rounded-md border-2 font-mono font-black",
-				{
-					"border-zinc-700 text-zinc-700": !pit && !on && !possible,
-					"border-zinc-400 text-zinc-400": !pit && !on && possible,
-					"border-emerald-500 text-emerald-500": !pit && on,
-					"border-cyan-500 text-cyan-500": pit,
-				},
+				colors,
 			)}
+			data-tooltip-id="tooltip"
+			data-tooltip-content={tooltip}
 		>
 			{pit ? "PIT" : "DRS"}
 		</span>

--- a/dash/src/components/driver/DriverGap.tsx
+++ b/dash/src/components/driver/DriverGap.tsx
@@ -28,10 +28,18 @@ export default function DriverGap({ timingDriver, sessionPart }: Props) {
 					"text-emerald-500": catching,
 					"text-zinc-600": !gapToFront,
 				})}
+				data-tooltip-id="tooltip"
+				data-tooltip-content={!!gapToFront ? "Gap to next car" : null}
 			>
 				{!!gapToFront ? gapToFront : "-- ---"}
 			</p>
-			<p className="text-sm font-medium leading-none text-zinc-600">{!!gapToLeader ? gapToLeader : "-- ---"}</p>
+			<p
+				className="text-sm font-medium leading-none text-zinc-600"
+				data-tooltip-id="tooltip"
+				data-tooltip-content={!!gapToFront ? "Gap to leader" : null}
+			>
+				{!!gapToLeader ? gapToLeader : "-- ---"}
+			</p>
 		</div>
 	);
 }

--- a/dash/src/components/driver/DriverInfo.tsx
+++ b/dash/src/components/driver/DriverInfo.tsx
@@ -34,6 +34,8 @@ export default function DriverInfo({ timingDriver, gridPos }: Props) {
 					"text-red-500": loss,
 					"text-gray-700": !gain && !loss,
 				})}
+				data-tooltip-id="tooltip"
+				data-tooltip-content={positionChange !== undefined ? "Position change" : "Lap count"}
 			>
 				{positionChange !== undefined
 					? gain
@@ -44,7 +46,13 @@ export default function DriverInfo({ timingDriver, gridPos }: Props) {
 					: `${timingDriver.numberOfLaps}L`}
 			</p>
 
-			<p className="text-sm font-medium leading-none text-zinc-600">{status ?? "-"}</p>
+			<p
+				className="text-sm font-medium leading-none text-zinc-600"
+				data-tooltip-id="tooltip"
+				data-tooltip-content="Status"
+			>
+				{status ?? "-"}
+			</p>
 		</div>
 	);
 }

--- a/dash/src/components/driver/DriverLapTime.tsx
+++ b/dash/src/components/driver/DriverLapTime.tsx
@@ -18,6 +18,8 @@ export default function DriverLapTime({ last, best, hasFastest }: Props) {
 					getTimeColor(last.overallFastest, last.personalFastest),
 					!last.value ? "text-zinc-600" : "",
 				)}
+				data-tooltip-id="tooltip"
+				data-tooltip-content="Last lap time"
 			>
 				{!!last.value ? last.value : "-- -- ---"}
 			</p>
@@ -27,6 +29,8 @@ export default function DriverLapTime({ last, best, hasFastest }: Props) {
 					getTimeColor(hasFastest, true),
 					!best.value ? "text-zinc-600" : "",
 				)}
+				data-tooltip-id="tooltip"
+				data-tooltip-content="Best lap time"
 			>
 				{!!best.value ? best.value : "-- -- ---"}
 			</p>

--- a/dash/src/components/driver/DriverMiniSectors.tsx
+++ b/dash/src/components/driver/DriverMiniSectors.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 
 import { getTimeColor } from "@/lib/getTimeColor";
-import { TimingDataDriver, TimingStatsDriver } from "@/types/state.type";
+import { Sector, TimingDataDriver, TimingStatsDriver } from "@/types/state.type";
 import { useSettingsStore } from "@/stores/useSettingsStore";
 
 type Props = {
@@ -13,6 +13,23 @@ type Props = {
 export default function DriverMiniSectors({ sectors = [], bestSectors, tla }: Props) {
 	const showMiniSectors = useSettingsStore((state) => state.showMiniSectors);
 	const showBestSectors = useSettingsStore((state) => state.showBestSectors);
+
+	const sectorTimeTooltip = (sector: Sector, index: number) => {
+		const sectorName = `Sector ${index + 1}`;
+		if (sector.overallFastest) {
+			return `Overall Best ${sectorName}`;
+		}
+		if (sector.personalFastest) {
+			return `Personal Best ${sectorName}`;
+		}
+		if (!!sector.value) {
+			return sectorName;
+		}
+		if (!!sector.previousValue) {
+			return `${sectorName} (previous)`;
+		}
+		return null;
+	};
 
 	return (
 		<div className="flex gap-2">
@@ -37,12 +54,18 @@ export default function DriverMiniSectors({ sectors = [], bestSectors, tla }: Pr
 								getTimeColor(sector.overallFastest, sector.personalFastest),
 								!sector.value ? "text-zinc-600" : "",
 							)}
+							data-tooltip-id="tooltip"
+							data-tooltip-content={sectorTimeTooltip(sector, i)}
 						>
 							{!!sector.value ? sector.value : !!sector.previousValue ? sector.previousValue : "-- ---"}
 						</p>
 
 						{showBestSectors && (
-							<p className="text-sm font-medium leading-none text-zinc-600">
+							<p
+								className="text-sm font-medium leading-none text-zinc-600"
+								data-tooltip-id="tooltip"
+								data-tooltip-content={bestSectors && bestSectors[i].value ? `Best sector ${i + 1}` : null}
+							>
 								{bestSectors && bestSectors[i].value ? bestSectors[i].value : "-- ---"}
 							</p>
 						)}
@@ -54,16 +77,36 @@ export default function DriverMiniSectors({ sectors = [], bestSectors, tla }: Pr
 }
 
 function MiniSector({ status, wide }: { status: number; wide: boolean }) {
+	let color = null;
+	let tooltip = null;
+	switch (status) {
+		case 2048:
+		case 2052: // TODO unsure
+			color = "bg-yellow-500";
+			break;
+		case 2049:
+			color = "bg-emerald-500";
+			tooltip = "Personal Best (mini-sector)";
+			break;
+		case 2051:
+			color = "bg-violet-500";
+			tooltip = "Overall Best (mini-sector)";
+			break;
+		case 2064:
+			color = "bg-blue-500";
+			tooltip = "Pit Lane";
+			break;
+		case 0:
+			color = "bg-zinc-700";
+			break;
+	}
+
 	return (
 		<div
 			style={wide ? { width: 10, height: 5, borderRadius: 2 } : { height: 10, width: 8, borderRadius: 3.2 }}
-			className={clsx({
-				"bg-yellow-500": status === 2048 || status === 2052, // TODO unsure
-				"bg-emerald-500": status === 2049,
-				"bg-violet-600": status === 2051,
-				"bg-blue-500": status === 2064,
-				"bg-zinc-700": status === 0,
-			})}
+			className={clsx(color)}
+			data-tooltip-id="tooltip"
+			data-tooltip-content={tooltip}
 		/>
 	);
 }

--- a/dash/src/components/driver/DriverPedals.tsx
+++ b/dash/src/components/driver/DriverPedals.tsx
@@ -7,13 +7,18 @@ type Props = {
 	value: number;
 	maxValue: number;
 	className: string;
+	tooltip?: string;
 };
 
-export default function DriverPedals({ className, value, maxValue }: Props) {
+export default function DriverPedals({ className, value, maxValue, tooltip }: Props) {
 	const progress = value / maxValue;
 
 	return (
-		<div className="h-1.5 w-20 overflow-hidden rounded-xl bg-zinc-800">
+		<div
+			className="h-1.5 w-20 overflow-hidden rounded-xl bg-zinc-800"
+			data-tooltip-id="tooltip"
+			data-tooltip-content={tooltip}
+		>
 			<motion.div
 				className={clsx("h-1.5", className)}
 				style={{ width: `${progress * 100}%` }}

--- a/dash/src/components/driver/DriverTag.tsx
+++ b/dash/src/components/driver/DriverTag.tsx
@@ -1,13 +1,17 @@
 import clsx from "clsx";
 
+import type { Driver } from "@/types/state.type";
+
 type Props = {
-	teamColor: string;
-	short: string;
+	driver: Driver;
 	position?: number;
 	className?: string;
+	statusTooltip?: string;
 };
 
-export default function DriverTag({ position, teamColor, short, className }: Props) {
+export default function DriverTag({ driver, position, className, statusTooltip }: Props) {
+	const teamColor = driver.teamColour;
+	const short = driver.tla;
 	return (
 		<div
 			id="walkthrough-driver-position"
@@ -16,10 +20,16 @@ export default function DriverTag({ position, teamColor, short, className }: Pro
 				className,
 			)}
 			style={{ backgroundColor: `#${teamColor}` }}
+			data-tooltip-id="tooltip"
+			data-tooltip-content={statusTooltip}
 		>
 			{position && <p className="px-1 text-xl leading-none">{position}</p>}
 
-			<div className="flex h-min w-min items-center justify-center rounded-md bg-white px-1">
+			<div
+				className="flex h-min w-min items-center justify-center rounded-md bg-white px-1"
+				data-tooltip-id="tooltip"
+				data-tooltip-content={`${driver.fullName} #${driver.racingNumber}`}
+			>
 				<p className="font-mono text-zinc-600" style={{ ...(teamColor && { color: `#${teamColor}` }) }}>
 					{short}
 				</p>

--- a/dash/src/components/driver/DriverTire.tsx
+++ b/dash/src/components/driver/DriverTire.tsx
@@ -9,35 +9,53 @@ type Props = {
 export default function DriverTire({ stints }: Props) {
 	const stops = stints ? stints.length - 1 : 0;
 	const currentStint = stints ? stints[stints.length - 1] : null;
-	const unknownCompound = !["soft", "medium", "hard", "intermediate", "wet"].includes(
-		currentStint?.compound?.toLowerCase() ?? "",
-	);
+	const compound = currentStint?.compound;
+	const unknownCompound = !["soft", "medium", "hard", "intermediate", "wet"].includes(compound?.toLowerCase() ?? "");
 
 	return (
 		<div className="flex flex-row items-center gap-2 place-self-start" id="walkthrough-driver-tire">
-			{currentStint && !unknownCompound && currentStint.compound && (
+			{currentStint && !unknownCompound && compound && (
 				<Image
-					src={"/tires/" + currentStint.compound.toLowerCase() + ".svg"}
+					src={"/tires/" + compound.toLowerCase() + ".svg"}
 					width={32}
 					height={32}
-					alt={currentStint.compound}
+					alt={compound}
+					data-tooltip-id="tooltip"
+					data-tooltip-content={compound[0] + compound.slice(1).toLowerCase() + " tires"}
 				/>
 			)}
 
 			{currentStint && unknownCompound && (
 				<div className="flex h-8 w-8 items-center justify-center">
-					<Image src={"/tires/unknown.svg"} width={32} height={32} alt={"unknown"} />
+					<Image
+						src={"/tires/unknown.svg"}
+						width={32}
+						height={32}
+						alt={"unknown"}
+						data-tooltip-id="tooltip"
+						data-tooltip-content="Unknown tires"
+					/>
 				</div>
 			)}
 
 			{!currentStint && <div className="h-8 w-8 animate-pulse rounded-full bg-zinc-800 font-semibold" />}
 
 			<div>
-				<p className="font-bold leading-none">
+				<p
+					className="font-bold leading-none"
+					data-tooltip-id="tooltip"
+					data-tooltip-content={"Tire age" + (currentStint?.new ? "" : " (old)")}
+				>
 					L {currentStint?.totalLaps ?? 0}
 					{currentStint?.new ? "" : "*"}
 				</p>
-				<p className="text-sm font-medium leading-none text-zinc-600">PIT {stops}</p>
+				<p
+					className="text-sm font-medium leading-none text-zinc-600"
+					data-tooltip-id="tooltip"
+					data-tooltip-content="# pit stops"
+				>
+					PIT {stops}
+				</p>
 			</div>
 		</div>
 	);

--- a/dash/src/stores/useSettingsStore.ts
+++ b/dash/src/stores/useSettingsStore.ts
@@ -34,6 +34,9 @@ type SettingsStore = {
 
 	raceControlChimeVolume: number;
 	setRaceControlChimeVolume: (raceControlChimeVolume: number) => void;
+
+	showTooltips: boolean;
+	setShowTooltips: (showTooltips: boolean) => void;
 };
 
 export const useSettingsStore = create(
@@ -71,6 +74,9 @@ export const useSettingsStore = create(
 
 				raceControlChimeVolume: 50,
 				setRaceControlChimeVolume: (raceControlChimeVolume: number) => set({ raceControlChimeVolume }),
+
+				showTooltips: true,
+				setShowTooltips: (showTooltips: boolean) => set({ showTooltips }),
 			}),
 			{
 				name: "settings-storage",

--- a/dash/yarn.lock
+++ b/dash/yarn.lock
@@ -52,6 +52,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/dom@npm:^1.6.1":
+  version: 1.6.13
+  resolution: "@floating-ui/dom@npm:1.6.13"
+  dependencies:
+    "@floating-ui/core": "npm:^1.6.0"
+    "@floating-ui/utils": "npm:^0.2.9"
+  checksum: 10c0/272242d2eb6238ffcee0cb1f3c66e0eafae804d5d7b449db5ecf904bc37d31ad96cf575a9e650b93c1190f64f49a684b1559d10e05ed3ec210628b19116991a9
+  languageName: node
+  linkType: hard
+
 "@floating-ui/react-dom@npm:^2.1.2":
   version: 2.1.2
   resolution: "@floating-ui/react-dom@npm:2.1.2"
@@ -82,6 +92,13 @@ __metadata:
   version: 0.2.8
   resolution: "@floating-ui/utils@npm:0.2.8"
   checksum: 10c0/a8cee5f17406c900e1c3ef63e3ca89b35e7a2ed645418459a73627b93b7377477fc888081011c6cd177cac45ec2b92a6cab018c14ea140519465498dddd2d3f9
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@floating-ui/utils@npm:0.2.9"
+  checksum: 10c0/48bbed10f91cb7863a796cc0d0e917c78d11aeb89f98d03fc38d79e7eb792224a79f538ed8a2d5d5584511d4ca6354ef35f1712659fd569868e342df4398ad6f
   languageName: node
   linkType: hard
 
@@ -831,6 +848,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"classnames@npm:^2.3.0":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
+  languageName: node
+  linkType: hard
+
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -1043,6 +1067,7 @@ __metadata:
     prettier-plugin-tailwindcss: "npm:0.6.8"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
+    react-tooltip: "npm:^5.28.0"
     sharp: "npm:0.33.5"
     tailwindcss: "npm:3.4.15"
     typescript: "npm:5.6.3"
@@ -2014,6 +2039,19 @@ __metadata:
   peerDependencies:
     react: ^18.3.1
   checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
+  languageName: node
+  linkType: hard
+
+"react-tooltip@npm:^5.28.0":
+  version: 5.28.0
+  resolution: "react-tooltip@npm:5.28.0"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.6.1"
+    classnames: "npm:^2.3.0"
+  peerDependencies:
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
+  checksum: 10c0/817909584adf4d84d70768e41c7fdf66bf9affd980499742a2da54378e5c8be53a0867bf72bdfb441fa4aa35c79847585990b6e31c91e6647e789ba68e9b08a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
f1-dash is incredible, and simultaneously has a _lot_ of information on it to absorb as you begin using it. The Help page is useful, but is also a click away—which might cause de-sync or delay issues if you're trying to learn how the dashboard works in the middle of a race.

This PR introduces tooltips throughout the Dashboard UI. This way, users can see explainers for what various color/opacity combos mean across the UI just by hovering over the elements. I've used `react-tooltip` to support this, and now the UI is self-documenting as you use it.

<img width="350" alt="Hovering over 'HAM' and the tooltip shows 'Lewis HAMILTON #44'" src="https://github.com/user-attachments/assets/c1534398-fc41-4cf6-b33e-3ad3dd82c2b0" /><br/><br/>
<img width="350" alt="Tooltip reads 'Track temp' over one of the temperature dials" src="https://github.com/user-attachments/assets/8e9335c4-e9c9-4313-8141-c7ef42ecb69e" /><br/><br/>
<img width="106" alt="Tooltip reads 'Brake' for the driver controls" src="https://github.com/user-attachments/assets/c572f7b0-92e5-45f0-89a8-057802c0bfdc" />


If anyone doesn't like the tooltips, they can also be turned off from the user settings:
<img width="300" alt="Settings page includes 'Show tooltips'" src="https://github.com/user-attachments/assets/058e0369-6934-4ae9-93ec-85a34b4f19dd" />

I followed the contributing guildelines, ran prettier on all modified files, build passes, and `yarn start` is where I took these screenshots.

