### PR TITLE
feat: add back safety car to track map

### DIFF
--- a/dash/src/components/Map.tsx
+++ b/dash/src/components/Map.tsx
@@ -171,6 +171,21 @@ export default function Map() {
 
 			{centerX && centerY && positions && drivers && (
 				<>
+				{positions["241"] && (
+					<CarDot
+						key={`map.car.241`}
+						favoriteDriver={false}
+						name="Safety Car"
+						pit={false}
+						hidden={false}
+						pos={positions["241"]}
+						color={undefined}
+						rotation={rotation}
+						centerX={centerX}
+						centerY={centerY}
+					/>
+				)}
+
 					{objectEntries(drivers)
 						.reverse()
 						.filter((driver) => !!positions[driver.racingNumber].X && !!positions[driver.racingNumber].Y)


### PR DESCRIPTION
Adds the safety car back to the track map. Basically undos #172 since the data in fact seems to be there again. Tested with the Saudi Arabian Grand Prix and it worked. I think the color of the safety car should be reconsidered, but idk what would look best.