### PR TITLE
feat: add color to safety car

### DIFF
--- a/dash/src/app/dashboard/settings/page.tsx
+++ b/dash/src/app/dashboard/settings/page.tsx
@@ -52,6 +52,11 @@ export default function SettingsPage() {
 				<p className="text-zinc-500">OLED Mode (Pure Black Background)</p>
 			</div>
 
+			<div className="flex gap-2">
+				<Toggle enabled={settings.useSafetyCarColors} setEnabled={(v) => settings.setUseSafetyCarColors(v)} />
+				<p className="text-zinc-500">Use Safety Car Colors</p>
+			</div>
+
 			<h2 className="my-4 text-2xl">Race Control</h2>
 
 			<div className="flex gap-2">

--- a/dash/src/components/dashboard/Map.tsx
+++ b/dash/src/components/dashboard/Map.tsx
@@ -174,32 +174,38 @@ export default function Map() {
 			{centerX && centerY && positions && drivers && (
 				<>
 					{positions["241"] && positions["241"].Z !== 0 && (
+						// Aston Martin
 						<SafetyCar
 							key="safety.car.241"
 							rotation={rotation}
 							centerX={centerX}
 							centerY={centerY}
 							pos={positions["241"]}
+							color="229971"
 						/>
 					)}
 
 					{positions["242"] && positions["242"].Z !== 0 && (
+						// Aston Martin
 						<SafetyCar
 							key="safety.car.242"
 							rotation={rotation}
 							centerX={centerX}
 							centerY={centerY}
 							pos={positions["242"]}
+							color="229971"
 						/>
 					)}
 
 					{positions["243"] && positions["243"].Z !== 0 && (
+						// Mercedes
 						<SafetyCar
 							key="safety.car.243"
 							rotation={rotation}
 							centerX={centerX}
 							centerY={centerY}
 							pos={positions["243"]}
+							color="B90F09"
 						/>
 					)}
 
@@ -307,9 +313,12 @@ type SafetyCarProps = {
 	rotation: number;
 	centerX: number;
 	centerY: number;
+	color: string;
 };
 
-const SafetyCar = ({ pos, rotation, centerX, centerY }: SafetyCarProps) => {
+const SafetyCar = ({ pos, rotation, centerX, centerY, color }: SafetyCarProps) => {
+	const useSafetyCarColors = useSettingsStore((state) => state.useSafetyCarColors);
+
 	return (
 		<CarDot
 			name="Safety Car"
@@ -320,7 +329,7 @@ const SafetyCar = ({ pos, rotation, centerX, centerY }: SafetyCarProps) => {
 			favoriteDriver={false}
 			pit={false}
 			hidden={false}
-			color={undefined}
+			color={useSafetyCarColors ? color : "DDD"}
 		/>
 	);
 };

--- a/dash/src/stores/useSettingsStore.ts
+++ b/dash/src/stores/useSettingsStore.ts
@@ -28,6 +28,9 @@ type SettingsStore = {
 	oledMode: boolean;
 	setOledMode: (oledMode: boolean) => void;
 
+	useSafetyCarColors: boolean;
+	setUseSafetyCarColors: (useSafetyCarColors: boolean) => void;
+
 	favoriteDrivers: string[];
 	setFavoriteDrivers: (favoriteDrivers: string[]) => void;
 	removeFavoriteDriver: (driver: string) => void;
@@ -69,6 +72,9 @@ export const useSettingsStore = create<SettingsStore>()(
 
 				oledMode: false,
 				setOledMode: (oledMode: boolean) => set({ oledMode }),
+
+				useSafetyCarColors: false,
+				setUseSafetyCarColors: (useSafetyCarColors: boolean) => set({ useSafetyCarColors }),
 
 				favoriteDrivers: [],
 				setFavoriteDrivers: (favoriteDrivers: string[]) => set({ favoriteDrivers }),

--- a/dash/src/stores/useSettingsStore.ts
+++ b/dash/src/stores/useSettingsStore.ts
@@ -73,7 +73,7 @@ export const useSettingsStore = create<SettingsStore>()(
 				oledMode: false,
 				setOledMode: (oledMode: boolean) => set({ oledMode }),
 
-				useSafetyCarColors: false,
+				useSafetyCarColors: true,
 				setUseSafetyCarColors: (useSafetyCarColors: boolean) => set({ useSafetyCarColors }),
 
 				favoriteDrivers: [],


### PR DESCRIPTION
Adds a toggle option in settings to toggle between using the safety car color and white (almost). The Mercedes color I picked kind of arbitrarily, the Aston Martin color I took from the team color in data from F1.