### PR TITLE
fix: fixed simulator getting out of sync

### DIFF
--- a/crates/simulator/src/main.rs
+++ b/crates/simulator/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     fs::File,
     io::{self, BufRead},
     path::Path,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use tokio::{
@@ -66,8 +66,11 @@ async fn main() {
 
         info!("reader has started broadcasting lines");
 
+        let start = Instant::now();
+
         for line in lines {
-            sleep(Duration::from_millis(interval_ms)).await;
+            let interval = interval_ms - start.elapsed().as_millis() as u64 % interval_ms;
+            sleep(Duration::from_millis(interval)).await;
 
             match line {
                 Ok(txt) => {


### PR DESCRIPTION
This fixes the issue where the simulator gets more and more out of sync by accounting for the time it takes to broadcast a line when determining the delay before broadcasting the next one. This is necessary for simulating a past race in real time.