### PR TITLE
feat: create replay generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,23 @@ cargo r -p saver year-circuit.data.txt
 > I recommend naming the files with the ending 
 > ".data.txt" as this extension is in the gitignore so you won't accidentally commit the telemetry recordings.
 
+You can also create a recording of a past race using the generator. Just start it up and select the year, meeting, and session.
+
+```bash
+cd f1-dash/
+
+# Run the generator
+cargo r -p generator
+```
+
+> [!NOTE]
+> Not all past races are available using the generator. The following races are unavailable:
+> - All seasons before 2018
+> - The 2018 Australian Grand Prix
+> - 2020 and 2021 pre-season testing
+> - The 2022 season
+> - All races before Spain in 2024
+
 ## Branching Convention
 
 For branch names we use git flow style branching.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot 0.12.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +579,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -785,12 +816,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "data",
+ "inquire",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1219,6 +1271,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1467,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -1422,6 +1503,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1849,7 +1939,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2073,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2141,6 +2233,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2618,7 +2731,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2863,6 +2976,18 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "services/importer",  # bin - service
     "crates/saver",       # bin - util
     "crates/simulator",   # bin - util
+    "crates/generator",   # lib, bin - util
 ]
 default-members = [
     "services/live",

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "generator"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+chrono = { version = "0.4.41", features = ["alloc"] }
+reqwest = { workspace = true, features = ["blocking"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+data.workspace = true
+inquire = "0.7.5"

--- a/crates/generator/readme.md
+++ b/crates/generator/readme.md
@@ -1,0 +1,17 @@
+# Generator
+
+Generates a replay file of a chosen race that the simulator is able to read.
+
+## Usage
+
+```bash
+cargo r -p generator
+```
+
+> [!NOTE]
+> Not all past races are available using the generator. The following races are unavailable:
+> - All seasons before 2018
+> - The 2018 Australian Grand Prix
+> - 2020 and 2021 pre-season testing
+> - The 2022 season
+> - All races before Spain in 2024

--- a/crates/generator/src/lib.rs
+++ b/crates/generator/src/lib.rs
@@ -1,0 +1,461 @@
+use std::{
+    io::{self, Write},
+    sync::mpsc,
+    thread,
+};
+
+use chrono::{DateTime, SecondsFormat};
+use data::merge::merge;
+use inquire::{CustomType, Select, error::InquireResult};
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+const REQUIRED_FEEDS: [&'static str; 20] = [
+    "Heartbeat",
+    "CarData.z",
+    "Position.z",
+    "ExtrapolatedClock",
+    "TopThree",
+    "RcmSeries",
+    "TimingStats",
+    "TimingAppData",
+    "WeatherData",
+    "TrackStatus",
+    "SessionStatus",
+    "DriverList",
+    "RaceControlMessages",
+    "SessionInfo",
+    "SessionData",
+    "LapCount",
+    "TimingData",
+    "TeamRadio",
+    "PitLaneTimeCollection",
+    "ChampionshipPrediction",
+];
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct Session {
+    pub key: u16,
+    pub r#type: String,
+    #[serde(default)]
+    pub number: i8,
+    pub name: String,
+    pub start_date: String,
+    pub end_date: String,
+    pub gmt_offset: String,
+    pub path: String,
+}
+
+impl std::fmt::Display for Session {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct Country {
+    pub key: u16,
+    pub code: String,
+    pub name: String,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct Circuit {
+    pub key: u16,
+    pub short_name: String,
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct Meeting {
+    pub sessions: Vec<Session>,
+    pub key: u16,
+    pub code: String,
+    pub number: u8,
+    pub location: String,
+    pub official_name: String,
+    pub name: String,
+    pub country: Country,
+    pub circuit: Circuit,
+}
+
+impl std::fmt::Display for Meeting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct YearIndex {
+    pub year: u16,
+    pub meetings: Vec<Meeting>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct RaceFeeds {
+    pub feeds: Map<String, Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all(deserialize = "PascalCase"))]
+pub struct Heartbeat {
+    pub utc: String,
+}
+
+#[derive(Clone)]
+pub struct Message {
+    pub name: String,
+    pub data: Value,
+    pub time: u64,
+}
+
+#[derive(Clone)]
+pub struct RawReplay {
+    pub messages: Vec<Message>,
+    pub base_time: Option<u64>,
+    pub start_time: Option<u64>,
+}
+
+#[derive(Debug)]
+pub enum JsonRequestError {
+    ReqwestErr(reqwest::Error),
+    JsonErr(serde_json::Error),
+}
+
+impl From<reqwest::Error> for JsonRequestError {
+    fn from(value: reqwest::Error) -> Self {
+        Self::ReqwestErr(value)
+    }
+}
+
+impl From<serde_json::Error> for JsonRequestError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::JsonErr(value)
+    }
+}
+
+impl std::fmt::Display for JsonRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonRequestError::ReqwestErr(e) => write!(f, "{e}"),
+            JsonRequestError::JsonErr(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+pub fn get_meetings(year: u16) -> Result<YearIndex, JsonRequestError> {
+    let res = reqwest::blocking::get(format!(
+        "https://livetiming.formula1.com/static/{year}/Index.json"
+    ))?
+    .text()?;
+    Ok(serde_json::from_str(res.trim_start_matches("\u{feff}"))?)
+}
+
+pub fn get_race_feeds(session: &Session) -> Result<Vec<String>, JsonRequestError> {
+    let res = reqwest::blocking::get(format!(
+        "https://livetiming.formula1.com/static/{}Index.json",
+        session.path
+    ))?
+    .text()?;
+    Ok(
+        serde_json::from_str::<RaceFeeds>(res.trim_start_matches("\u{feff}"))?
+            .feeds
+            .keys()
+            .map(|feed| feed.clone())
+            .collect(),
+    )
+}
+
+fn get_feed_data(client: &Client, path: &String, name: &String) -> reqwest::Result<String> {
+    client
+        .get(format!(
+            "https://livetiming.formula1.com/static/{path}{name}.jsonStream"
+        ))
+        .send()?
+        .text()
+}
+
+pub fn select_year() -> InquireResult<u16> {
+    CustomType::<u16>::new("Choose a year")
+        .with_error_message("Invalid year")
+        .prompt()
+}
+
+pub fn select_meeting(meetings: &Vec<Meeting>) -> InquireResult<Meeting> {
+    let mut options = meetings.clone();
+    options.reverse();
+    Select::new("Choose a meeting", options)
+        .with_page_size(meetings.len())
+        .prompt()
+}
+
+pub fn select_session(sessions: &Vec<Session>) -> InquireResult<Session> {
+    let mut options = sessions.clone();
+    options.reverse();
+    Select::new("Choose a session", options)
+        .with_page_size(sessions.len())
+        .prompt()
+}
+
+pub fn select_year_index() -> YearIndex {
+    loop {
+        let year = select_year().expect("Failed to read input");
+        match get_meetings(year) {
+            Ok(year_index) => {
+                if !year_index.meetings.is_empty() {
+                    return year_index;
+                }
+                eprintln!("No races available for {year}")
+            }
+            Err(error) => match error {
+                JsonRequestError::ReqwestErr(error) => eprintln!("{error}"),
+                JsonRequestError::JsonErr(_) => eprintln!("No races available for {year}"),
+            },
+        }
+    }
+}
+
+fn parse_line(line: &str) -> (u64, Value) {
+    let line = line.trim_start_matches("\u{feff}");
+    let time = time_to_ms(&line[0..12]);
+    let data: Value = line[12..].parse().expect("Invalid data");
+
+    (time, data)
+}
+
+fn time_to_ms(time: &str) -> u64 {
+    const MS_IN_HOUR: u64 = 1000 * 60 * 60;
+    const MS_IN_MINUTE: u64 = 1000 * 60;
+    const MS_IN_SECOND: u64 = 1000;
+
+    let [hours, mins, secs_and_ms] = time.split(":").collect::<Vec<_>>()[0..3] else {
+        panic!("Invalid time format")
+    };
+    let [secs, ms] = secs_and_ms.split(".").collect::<Vec<_>>()[0..2] else {
+        panic!("Invalid time format")
+    };
+    let hours: u64 = hours.parse().expect("Invalid hours");
+    let mins: u64 = mins.parse().expect("Invalid minutes");
+    let secs: u64 = secs.parse().expect("Invalid seconds");
+    let ms: u64 = ms.parse().expect("Invalid milliseconds");
+
+    hours * MS_IN_HOUR + mins * MS_IN_MINUTE + secs * MS_IN_SECOND + ms
+}
+
+fn calculate_base_time(time: u64, heartbeat_data: &Value) -> Option<u64> {
+    let heartbeat = serde_json::from_value::<Heartbeat>(heartbeat_data.clone()).ok()?;
+    let date = DateTime::parse_from_rfc3339(&heartbeat.utc).ok()?;
+    let timestamp = date.timestamp_millis();
+    if timestamp < 0 {
+        return None;
+    };
+    Some(timestamp as u64 - time)
+}
+
+fn calculate_start_time(session: &Session) -> Option<u64> {
+    let offset_str = session.gmt_offset.split(":").collect::<Vec<_>>()[0..2].join(":");
+    let offset_str = if session.gmt_offset.starts_with("-") {
+        offset_str
+    } else {
+        format!("+{offset_str}")
+    };
+    match DateTime::parse_from_rfc3339(&format!("{}{}", session.start_date, offset_str)) {
+        Ok(date) => {
+            let timestamp = date.timestamp_millis();
+            if timestamp < 0 {
+                None
+            } else {
+                Some(timestamp as u64)
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+fn create_inital_message(messages: Vec<&Message>) -> String {
+    let mut data = Map::new();
+    for message in messages {
+        if data.contains_key(&message.name) {
+            merge(data.get_mut(&message.name).unwrap(), message.data.clone());
+        } else {
+            data.insert(message.name.clone(), message.data.clone());
+        }
+    }
+    json!({
+        "I": 1,
+        "R": data
+    })
+    .to_string()
+}
+
+fn merge_messages(messages: Vec<&Message>, base_time: u64) -> String {
+    let m: Vec<Value> = messages
+        .iter()
+        .map(|message| {
+            json!({
+                "H": "Streaming",
+                "M": "feed",
+                "A": [
+                    message.name,
+                    message.data,
+                    DateTime::from_timestamp_millis((base_time + message.time) as i64)
+                        .expect("Something went wrong with the dates")
+                        .to_rfc3339_opts(SecondsFormat::Millis, true)
+                ]
+            })
+        })
+        .collect();
+    json!({
+        "M": m
+    })
+    .to_string()
+}
+
+enum ThreadMessage {
+    Message(Message),
+    BaseTime(u64),
+    Error(String, reqwest::Error),
+    Finished,
+}
+
+pub fn generate_raw_replay(session: &Session, show_progress_bar: bool) -> RawReplay {
+    let feeds = get_race_feeds(&session).unwrap_or(REQUIRED_FEEDS.map(String::from).to_vec());
+
+    let client = reqwest::blocking::Client::new();
+
+    let (tx, rx) = mpsc::channel();
+    let mut total_threads = 0;
+
+    for feed in feeds {
+        if !REQUIRED_FEEDS.contains(&feed.as_str()) {
+            continue;
+        }
+
+        let tx = tx.clone();
+        let client = client.clone();
+        let feed = feed.clone();
+        let path = session.path.clone();
+
+        thread::spawn(move || {
+            let data = get_feed_data(&client, &path, &feed).unwrap_or_else(|err| {
+                tx.send(ThreadMessage::Error(feed.clone(), err)).unwrap();
+                String::new()
+            });
+
+            let lines = data.lines();
+            let mut send_base_time = feed == "Heartbeat";
+
+            for line in lines {
+                let (time, data) = parse_line(line);
+
+                if send_base_time {
+                    if let Some(base_time) = calculate_base_time(time, &data) {
+                        tx.send(ThreadMessage::BaseTime(base_time)).unwrap();
+                        send_base_time = false;
+                    }
+                }
+
+                let message = Message {
+                    name: String::from(&feed),
+                    data,
+                    time,
+                };
+                tx.send(ThreadMessage::Message(message)).unwrap();
+            }
+
+            tx.send(ThreadMessage::Finished).unwrap();
+        });
+        total_threads += 1;
+    }
+
+    let mut messages: Vec<Message> = Vec::new();
+    let mut base_time: Option<u64> = None;
+    let mut threads_finished = 0;
+
+    for message in rx {
+        match message {
+            ThreadMessage::Message(message) => {
+                let i = messages.partition_point(|m| m.time <= message.time);
+                messages.insert(i, message);
+            }
+            ThreadMessage::BaseTime(bt) => {
+                if base_time == None {
+                    base_time = Some(bt)
+                }
+            }
+            ThreadMessage::Error(feed, err) => {
+                eprintln!("\rSomething went wrong with \"{feed}\": {err}")
+            }
+            ThreadMessage::Finished => {
+                threads_finished += 1;
+                if show_progress_bar {
+                    print!(
+                        "\r[{:num$}]",
+                        "#".repeat(threads_finished),
+                        num = total_threads
+                    );
+                    let _ = io::stdout().flush();
+                }
+            }
+        }
+        if threads_finished == total_threads {
+            break;
+        }
+    }
+
+    if show_progress_bar {
+        print!("\r{:size$}\r", "", size = total_threads + 2)
+    }
+
+    RawReplay {
+        messages,
+        base_time,
+        start_time: calculate_start_time(&session),
+    }
+}
+
+pub fn generate_replay(session: &Session, show_progress_bar: bool) -> String {
+    const FIVE_MINS_IN_TENTHS: u64 = 10 * 60 * 5;
+
+    let raw_replay = generate_raw_replay(session, show_progress_bar);
+
+    let base_time = raw_replay.base_time.unwrap_or(0);
+    let start_time = raw_replay.start_time.unwrap_or(base_time);
+
+    let messages = raw_replay.messages;
+
+    let end = messages.last().expect("No data").time / 100;
+    let start = (start_time - base_time) / 100 - FIVE_MINS_IN_TENTHS;
+
+    let mut out = String::new();
+    let mut i = 0;
+    for time in start..=end {
+        let mut message_group = Vec::new();
+        while let Some(message) = messages.get(i) {
+            if message.time / 100 <= time {
+                message_group.push(message);
+                i += 1;
+            } else {
+                break;
+            }
+        }
+        if time == start {
+            out.push_str(&create_inital_message(message_group));
+        } else {
+            if message_group.is_empty() {
+                out.push_str("{}");
+            } else {
+                out.push_str(&merge_messages(message_group, base_time));
+            }
+        }
+        out.push('\n');
+    }
+
+    out
+}

--- a/crates/generator/src/main.rs
+++ b/crates/generator/src/main.rs
@@ -1,0 +1,65 @@
+use std::{fs, path::Path};
+
+use generator::{generate_replay, select_meeting, select_session, select_year_index};
+use inquire::{Confirm, Text};
+
+fn to_kebab_case(string: &String) -> String {
+    let mut res = String::new();
+    for char in string.chars() {
+        res.push(if char == ' ' {
+            '-'
+        } else {
+            char.to_ascii_lowercase()
+        });
+    }
+    res
+}
+
+fn try_to_absolute(path: &Path) -> String {
+    std::path::absolute(path)
+        .unwrap_or(path.to_path_buf())
+        .display()
+        .to_string()
+}
+
+fn select_output_path(default: String) -> Box<Path> {
+    loop {
+        let file_name = Text::new("Output path:")
+            .with_default(&default)
+            .with_formatter(&|name| try_to_absolute(std::path::Path::new(name)))
+            .prompt()
+            .expect("Failed to read input");
+        let path = std::path::Path::new(&file_name);
+        if path.exists() {
+            let confirm = Confirm::new(&format!(
+                "File already exists at path {}. Replace it?",
+                path.display()
+            ))
+            .with_default(true)
+            .prompt()
+            .expect("Failed to read input");
+            if !confirm {
+                continue;
+            }
+        }
+        return path.into();
+    }
+}
+
+fn main() {
+    let year_index = select_year_index();
+    let meeting = select_meeting(&year_index.meetings).expect("Failed to read input");
+    let session = select_session(&meeting.sessions).expect("Failed to read input");
+    let path = select_output_path(format!(
+        "{}-{}-{}.data.txt",
+        &year_index.year,
+        to_kebab_case(&meeting.country.name),
+        to_kebab_case(&session.name)
+    ));
+
+    let replay = generate_replay(&session, true);
+
+    fs::write(&path, replay).expect("Failed to write to file");
+
+    println!("Replay created at {}", try_to_absolute(&path));
+}

--- a/dash/src/hooks/useDataEngine.ts
+++ b/dash/src/hooks/useDataEngine.ts
@@ -83,25 +83,25 @@ export const useDataEngine = ({ updateState, updatePosition, updateCarData }: Pr
 		}
 	};
 
-	const handleUpdate = ({ carDataZ, positionZ, ...update }: MessageUpdate) => {
-		Object.keys(buffers).forEach((key) => {
-			const data = update[key as keyof typeof update];
-			const buffer = buffers[key as keyof typeof buffers];
-			if (data) buffer.push(data);
-		});
-
-		if (carDataZ) {
-			const carData = inflate<CarData>(carDataZ);
-			for (const entry of carData.Entries) {
-				carBuffer.pushTimed(entry.Cars, utcToLocalMs(entry.Utc));
+	const handleUpdate = (updates: MessageUpdate) => {
+		for (const [topic, data] of updates) {
+			if (topic === "carDataZ" && data) {
+				const carData = inflate<CarData>(data);
+				for (const entry of carData.Entries) {
+					carBuffer.pushTimed(entry.Cars, utcToLocalMs(entry.Utc));
+				}
+				continue;
 			}
-		}
 
-		if (positionZ) {
-			const position = inflate<Position>(positionZ);
-			for (const entry of position.Position) {
-				posBuffer.pushTimed(entry.Entries, utcToLocalMs(entry.Timestamp));
+			if (topic === "positionZ" && data) {
+				const position = inflate<Position>(data);
+				for (const entry of position.Position) {
+					posBuffer.pushTimed(entry.Entries, utcToLocalMs(entry.Timestamp));
+				}
+				continue;
 			}
+
+			buffers[topic as keyof typeof buffers]?.push(data);
 		}
 	};
 

--- a/dash/src/hooks/useDevMode.ts
+++ b/dash/src/hooks/useDevMode.ts
@@ -1,9 +1,0 @@
-export const useDevMode = () => {
-	let active = false;
-
-	if (typeof window != undefined) {
-		active = !!localStorage.getItem("dev");
-	}
-
-	return { active };
-};

--- a/dash/src/hooks/useSocket.ts
+++ b/dash/src/hooks/useSocket.ts
@@ -22,7 +22,7 @@ export const useSocket = ({ handleInitial, handleUpdate }: Props) => {
 			handleInitial(JSON.parse(message.data));
 		});
 
-		sse.addEventListener("update", (message) => {
+		sse.addEventListener("updates", (message) => {
 			handleUpdate(JSON.parse(message.data));
 		});
 

--- a/dash/src/types/message.type.ts
+++ b/dash/src/types/message.type.ts
@@ -1,4 +1,22 @@
-import type { State } from "./state.type";
+import type {
+	ChampionshipPrediction,
+	DriverList,
+	ExtrapolatedClock,
+	Heartbeat,
+	LapCount,
+	RaceControlMessages,
+	SessionData,
+	SessionInfo,
+	SessionStatus,
+	State,
+	TeamRadio,
+	TimingAppData,
+	TimingData,
+	TimingStats,
+	TopThree,
+	TrackStatus,
+	WeatherData,
+} from "./state.type";
 
 export type RecursivePartial<T> = {
 	[P in keyof T]?: T[P] extends (infer U)[]
@@ -13,6 +31,27 @@ type FullState = State & {
 	positionZ?: string;
 };
 
-export type MessageUpdate = RecursivePartial<FullState>;
+export type UpdateState = {
+	heartbeat: Heartbeat;
+	extrapolatedClock: ExtrapolatedClock;
+	topThree: TopThree;
+	timingStats: TimingStats;
+	timingAppData: TimingAppData;
+	weatherData: WeatherData;
+	trackStatus: TrackStatus;
+	sessionStatus: SessionStatus;
+	driverList: DriverList;
+	raceControlMessages: RaceControlMessages;
+	sessionInfo: SessionInfo;
+	sessionData: SessionData;
+	lapCount: LapCount;
+	timingData: TimingData;
+	teamRadio: TeamRadio;
+	championshipPrediction: ChampionshipPrediction;
+	carDataZ: string;
+	positionZ: string;
+};
+
+export type MessageUpdate = { [K in keyof UpdateState]: [K, RecursivePartial<UpdateState[K]>] }[keyof UpdateState][];
 
 export type MessageInitial = FullState;

--- a/services/importer/src/main.rs
+++ b/services/importer/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), anyhow::Error> {
             Message::Updates(updates) => {
                 trace!(?updates, "recived updates, saving");
 
-                let currnet_state = state.lock().unwrap().clone();
+                let currnet_state = state.read().await.clone();
 
                 let _ = parse_update(&pool, currnet_state, updates).await;
             }

--- a/services/live/src/compression.rs
+++ b/services/live/src/compression.rs
@@ -9,81 +9,80 @@ use futures_util::stream::Stream;
 
 use std::io::Write;
 use std::pin::{pin, Pin};
-use std::task::Context;
-use std::task::Poll;
+use std::task::{Context, Poll};
 
 pub async fn compress_sse(request: Request, next: Next) -> Response {
-	let accept_encoding = request.headers().get(header::ACCEPT_ENCODING).cloned();
+    let accept_encoding = request.headers().get(header::ACCEPT_ENCODING).cloned();
 
-	let response = next.run(request).await;
+    let response = next.run(request).await;
 
-	let content_encoding = response.headers().get(header::CONTENT_ENCODING);
-	let content_type = response.headers().get(header::CONTENT_TYPE);
+    let content_encoding = response.headers().get(header::CONTENT_ENCODING);
+    let content_type = response.headers().get(header::CONTENT_TYPE);
 
-	// No accept-encoding from client or content-type from server.
-	let (Some(ct), Some(ae)) = (content_type, accept_encoding) else {
-		return response;
-	};
-	// Already compressed.
-	if content_encoding.is_some() {
-		return response;
-	}
-	// Not text/event-stream.
-	if ct.as_bytes() != b"text/event-stream" {
-		return response;
-	}
-	// Client doesn't accept gzip compression.
-	if !ae.to_str().map(|v| v.contains("gzip")).unwrap_or(false) {
-		return response;
-	}
+    // No accept-encoding from client or content-type from server.
+    let (Some(ct), Some(ae)) = (content_type, accept_encoding) else {
+        return response;
+    };
+    // Already compressed.
+    if content_encoding.is_some() {
+        return response;
+    }
+    // Not text/event-stream.
+    if ct.as_bytes() != b"text/event-stream" {
+        return response;
+    }
+    // Client doesn't accept gzip compression.
+    if !ae.to_str().map(|v| v.contains("gzip")).unwrap_or(false) {
+        return response;
+    }
 
-	let (mut parts, body) = response.into_parts();
+    let (mut parts, body) = response.into_parts();
 
-	let body = body.into_data_stream();
-	let body = Body::from_stream(CompressedStream::new(body));
+    let body = body.into_data_stream();
+    let body = Body::from_stream(CompressedStream::new(body));
 
-	parts.headers.insert(
-		header::CONTENT_ENCODING,
-		header::HeaderValue::from_static("gzip"),
-	);
-	parts.headers.insert(
-		header::VARY,
-		header::HeaderValue::from_static("accept-encoding"),
-	);
+    parts.headers.insert(
+        header::CONTENT_ENCODING,
+        header::HeaderValue::from_static("gzip"),
+    );
+    parts.headers.insert(
+        header::VARY,
+        header::HeaderValue::from_static("accept-encoding"),
+    );
 
-	Response::from_parts(parts, body)
+    Response::from_parts(parts, body)
 }
 
 struct CompressedStream {
-	inner: BodyDataStream,
-	compression: GzEncoder<Vec<u8>>,
+    inner: BodyDataStream,
+    compression: GzEncoder<Vec<u8>>,
 }
 
 impl CompressedStream {
-	pub fn new(body: BodyDataStream) -> Self {
-		Self {
-			inner: body,
-			compression: GzEncoder::new(Vec::new(), Compression::default()),
-		}
-	}
+    pub fn new(body: BodyDataStream) -> Self {
+        Self {
+            inner: body,
+            compression: GzEncoder::new(Vec::new(), Compression::default()),
+        }
+    }
 }
 
 impl Stream for CompressedStream {
-	type Item = Result<Bytes, axum::Error>;
+    type Item = Result<Bytes, axum::Error>;
 
-	#[inline]
-	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		match pin!(&mut self.inner).as_mut().poll_next(cx) {
-			Poll::Ready(Some(Ok(x))) => {
-				self.compression.write_all(&x).unwrap();
-				self.compression.flush().unwrap();
+    #[inline]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match pin!(&mut self.inner).as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(x))) => {
+                self.compression.write_all(&x).unwrap();
+                self.compression.flush().unwrap();
 
-				let mut buf = Vec::new();
-				std::mem::swap(&mut buf, self.compression.get_mut());
+                let mut buf = Vec::new();
+                std::mem::swap(&mut buf, self.compression.get_mut());
 
-				Poll::Ready(Some(Ok(buf.into())))
-			}
-			x => x,
-		}
-	}
+                Poll::Ready(Some(Ok(buf.into())))
+            }
+            x => x,
+        }
+    }
 }

--- a/services/live/src/main.rs
+++ b/services/live/src/main.rs
@@ -1,8 +1,4 @@
-use std::{
-    env,
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-};
+use std::{env, net::SocketAddr, sync::Arc};
 
 use axum::{
     http::{HeaderValue, Method},
@@ -12,6 +8,7 @@ use axum::{
 use compression::compress_sse;
 use dotenvy::dotenv;
 use serde_json::Value;
+use tokio::sync::RwLock;
 use tokio::{net::TcpListener, sync::broadcast};
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -28,7 +25,7 @@ mod server {
 
 pub struct AppState {
     tx: broadcast::Sender<Message>,
-    state: Arc<Mutex<Value>>,
+    state: Arc<RwLock<Value>>,
 }
 
 #[tokio::main]
@@ -70,7 +67,7 @@ async fn main() -> Result<(), anyhow::Error> {
 }
 
 pub fn cors_layer() -> Result<CorsLayer, anyhow::Error> {
-    let origin = env::var("ORIGIN")?; // origins string split by semicolumn
+    let origin = env::var("ORIGIN")?;
 
     let origins = origin
         .split(';')

--- a/services/live/src/server/drivers.rs
+++ b/services/live/src/server/drivers.rs
@@ -1,4 +1,4 @@
-use std::{mem, sync::Arc};
+use std::sync::Arc;
 
 use axum::extract::State;
 use serde_json::Value;
@@ -16,11 +16,8 @@ fn map_to_vec(value: Value) -> Vec<Value> {
 pub async fn get_drivers(
     State(state): State<Arc<AppState>>,
 ) -> Result<axum::Json<Vec<Value>>, axum::http::StatusCode> {
-    let state_lock = state.state.lock().unwrap();
-    let live_state = state_lock.clone();
-    mem::drop(state_lock);
-
-    match live_state.pointer("/driverList") {
+    let state_guard = state.state.read().await;
+    match state_guard.pointer("/driverList") {
         Some(drivers) => Ok(axum::Json(map_to_vec(drivers.clone()))),
         None => {
             error!("failed to get drivers from live state");

--- a/services/live/src/server/live.rs
+++ b/services/live/src/server/live.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, mem, sync::Arc, time::Duration};
+use std::{convert::Infallible, sync::Arc};
 
 use axum::{
     extract::State,
@@ -6,34 +6,22 @@ use axum::{
 };
 use client::message::Message;
 use futures::Stream;
-use serde_json::{json, Map, Value};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use tracing::{debug, info};
 
-use data::merge::merge;
-
 use crate::AppState;
 
-// TODO clean this up a bit maybe
-fn sse_event(message: Message) -> sse::Event {
-    let (event, data): (&str, Value) = match message {
-        Message::Updates(updates) => {
-            let mut batched_update = json!({});
-
-            for (topic, update) in updates {
-                let mut map = Map::new();
-                map.insert(topic, update);
-                merge(&mut batched_update, Value::Object(map));
-            }
-
-            // TODO maybe send the updates in array instead of object
-
-            ("update", batched_update)
-        }
-        Message::Initial(value) => ("initial", value),
-    };
-
-    sse::Event::default().event(event).json_data(data).unwrap()
+fn sse_event(message: Message) -> Option<sse::Event> {
+    match message {
+        Message::Updates(updates) => sse::Event::default()
+            .event("updates")
+            .json_data(updates)
+            .ok(),
+        Message::Initial(initial) => sse::Event::default()
+            .event("initial")
+            .json_data(initial)
+            .ok(),
+    }
 }
 
 pub async fn sse_handler(
@@ -44,13 +32,14 @@ pub async fn sse_handler(
 
     info!(connections, "new sse connection");
 
-    let initial_state_lock = state.state.lock().unwrap();
-    let initial_state = initial_state_lock.clone();
-    mem::drop(initial_state_lock);
+    // Use RwLock for concurrent reads and avoid unnecessary clone
+    let initial_state = {
+        let state_guard = state.state.read().await;
+        state_guard.clone()
+    };
 
     let initial_stream = futures::stream::once(async {
         debug!("streaming current initial");
-
         Ok(sse::Event::default()
             .event("initial")
             .json_data(initial_state)
@@ -59,14 +48,8 @@ pub async fn sse_handler(
 
     let updates_stream = BroadcastStream::new(rx)
         .filter_map(|msg| msg.ok())
-        .map(|message| sse_event(message))
+        .filter_map(sse_event)
         .map(Ok);
 
-    let stream = initial_stream.chain(updates_stream);
-
-    let keep_alive = sse::KeepAlive::new()
-        .interval(Duration::from_secs(10))
-        .text("keep-alive-text");
-
-    Sse::new(stream).keep_alive(keep_alive)
+    Sse::new(initial_stream.chain(updates_stream))
 }


### PR DESCRIPTION
This adds a crate that generates replay files for the simulator by pulling data from livetiming.formula1.com/static. Some things to note about the implementation:

- This is my second ever project in rust, so there may be places that my code isn't as good as it could be, but I have tried to go back and improve it since I learned a lot working on this. The project compiles with no errors or warnings and it works efficiently and as intended, and pretty much all errors are either recovered from or explained to the user.
- I used `inquire` to get user input since I don't think there would be a good way to get the info needed from the user through command line arguments, and although there are some things I don't like about `inquire`, overall I think it works well.
- As is mentioned in the readme, there are many races this can't get. That is not an issue with the code, but instead with Formula 1 not putting those races with everything else. As far as I know, they aren't available, but I have a friend with F1 TV Pro who is checking if they can access those races, and if they can, I'll try to figure out how to make that work here.
- The functions that get any sort of JSON data from F1 don't use `reqwest`'s JSON implementation because F1 "[illegally](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)" adds a byte order mark at the start of the responses, so that had to be handled separately. This is also why those functions use a custom error enum.
- When `get_meetings` returns a JSON error, the user is told that no races are available for that year. This is because for some reason, when a year with no data (or any invalid path) is requested, it returns an XML response saying "Access Denied" rather than the logical response of something in JSON. So, I interpret a JSON parse error as a year with no races available.
- `generate_raw_replay` and `generate_replay` are separated into two different functions to allow for different replay file formats in the future (since the current one isn't very good). I intend to make an improved format after I make some more improvements to the simulator, like play/pause and skipping around.
- This is multi-threaded because it speeds up the processing time quite a bit (~1100ms becomes ~150ms on my machine), and it also slightly speeds up the network requests. Also, if something goes wrong with the network request on any of the threads, it will print an error but will continue, since the replay file can still be created even if it's missing some data.
- The network requests are done using `reqwest::blocking`, which is synchronous, for two reasons.
  - It didn't seem necessary because it's already multi-threaded so the requests are running in parallel, and there's nothing else for it to do while waiting for the requests to finish.
  - I have no experience with async in rust, and I know that if I tried to use it here it would either be really badly written or I would spend way too long learning how to do async.
- This crate is both a binary and a library because I think it should be usable as a binary in the same way that `saver` and `simulator` are, but I also think it should get built into other crates. I'm planning to add it to the simulator, and I also think I could get added to something like the api, like in #163.
- This requires #294 to function correctly or else it will quickly get out of sync.

Let me know if you have any questions or suggestions.