### PR TITLE
feat(ui): replace DRS badge label with compact OVTK indicator

### DIFF
--- a/dashboard/src/components/driver/DriverDRS.tsx
+++ b/dashboard/src/components/driver/DriverDRS.tsx
@@ -9,11 +9,15 @@ type Props = {
 
 export default function DriverDRS({ on, possible, inPit, pitOut }: Props) {
 	const pit = inPit || pitOut;
+	const label = pit ? "PIT" : "OVTK";
+	const fullLabel = pit ? "PIT" : "OVERTAKE";
 
 	return (
 		<span
+			title={fullLabel}
+			aria-label={fullLabel}
 			className={clsx(
-				"text-md inline-flex h-8 w-full items-center justify-center rounded-md border-2 font-mono font-black",
+				"inline-flex h-8 w-full items-center justify-center rounded-md border-2 font-mono text-xs leading-none font-black tracking-tight sm:text-sm",
 				{
 					"border-zinc-700 text-zinc-700": !pit && !on && !possible,
 					"border-zinc-400 text-zinc-400": !pit && !on && possible,
@@ -22,7 +26,7 @@ export default function DriverDRS({ on, possible, inPit, pitOut }: Props) {
 				},
 			)}
 		>
-			{pit ? "PIT" : "DRS"}
+			{label}
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary
This PR updates the driver status badge to reflect current Formula 1 terminology by replacing the old `DRS` label with a compact `OVTK` label.

## What changed
- Updated `DriverDRS` badge text from `DRS` to `OVTK`
- Kept `PIT` label unchanged
- Adjusted badge typography/spacing so the new label fits the existing fixed-width column
- Added `title` and `aria-label` with full text (`OVERTAKE`) for clarity and accessibility

## Why
- `DRS` label is outdated in this context
- `OVERTAKE` is too long for the available UI space
- `OVTK` preserves readability without breaking the layout

## Impact
- No behavior or data logic changes
- Visual/text update only in the driver status badge component

## Files touched
- `dashboard/src/components/driver/DriverDRS.tsx`
<img width="996" height="547" alt="image" src="https://github.com/user-attachments/assets/c39ced1b-0b03-4f53-a252-e5b620d15dd6" />
