### PR TITLE
feat: add dedicated tire outings dashboard page

### DIFF
--- a/dashboard/src/app/(nav)/help/page.tsx
+++ b/dashboard/src/app/(nav)/help/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 import Note from "@/components/Note";
 import DriverDRS from "@/components/driver/DriverDRS";
@@ -150,6 +151,14 @@ export default function HelpPage() {
 				We also show the different tires a driver can use and how many laps they have done on them. <br />
 				In this example, the driver has a soft tire which is 12 laps old and he pitted one time.
 			</p>
+
+			<Note className="mb-4">
+				For a complete history of all tire stints and outings during the session, you can visit the dedicated{" "}
+				<Link href="/dashboard/tires" className="text-blue-500 underline">
+					Tires
+				</Link>{" "}
+				page in the dashboard.
+			</Note>
 
 			<div className="mb-4">
 				<DriverTire

--- a/dashboard/src/app/dashboard/tires/page.tsx
+++ b/dashboard/src/app/dashboard/tires/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import OutingTable from "@/components/dashboard/OutingTable";
 
 export default function TiresPage() {

--- a/dashboard/src/app/dashboard/tires/page.tsx
+++ b/dashboard/src/app/dashboard/tires/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import OutingTable from "@/components/dashboard/OutingTable";
+
+export default function TiresPage() {
+	return (
+		<div className="flex min-h-full w-full flex-col">
+			<div className="flex flex-col gap-1 border-b border-zinc-800 p-4">
+				<h1 className="text-2xl font-bold tracking-tight">Tire Outings</h1>
+				<p className="text-sm text-zinc-500">Real-time history of tire compounds and outing progression.</p>
+			</div>
+
+			<div className="flex-1">
+				<OutingTable />
+			</div>
+		</div>
+	);
+}

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -24,6 +24,10 @@ const liveTimingItems = [
 		name: "Track Map",
 	},
 	{
+		href: "/dashboard/tires",
+		name: "Tires",
+	},
+	{
 		href: "/dashboard/standings",
 		name: "Standings",
 	},

--- a/dashboard/src/components/dashboard/OutingTable.tsx
+++ b/dashboard/src/components/dashboard/OutingTable.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { AnimatePresence, LayoutGroup, motion } from "motion/react";
+import clsx from "clsx";
+
+import { useDataStore } from "@/stores/useDataStore";
+import { useSettingsStore } from "@/stores/useSettingsStore";
+import { sortPos } from "@/lib/sorting";
+
+import DriverTag from "@/components/driver/DriverTag";
+import DriverHistoryTires from "@/components/driver/DriverHistoryTires";
+
+export default function OutingTable() {
+	const drivers = useDataStore(({ state }) => state?.DriverList);
+	const driversTiming = useDataStore(({ state }) => state?.TimingData);
+	const appDriversTiming = useDataStore(({ state }) => state?.TimingAppData);
+
+	const oledMode = useSettingsStore((state) => state.oledMode);
+
+	return (
+		<div className="flex w-full flex-col">
+			<div
+				className="grid items-center gap-4 border-b border-zinc-800 bg-zinc-900/10 px-4 py-2 text-xs font-bold uppercase tracking-widest text-zinc-500"
+				style={{ gridTemplateColumns: "7rem 1fr" }}
+			>
+				<p>Driver</p>
+				<p>Tire History / Outings</p>
+			</div>
+
+			{(!drivers || !driversTiming) &&
+				new Array(20).fill("").map((_, index) => <SkeletonRow key={`outing.loading.${index}`} />)}
+
+			<LayoutGroup id="outings">
+				<div className="flex flex-col divide-y divide-zinc-800/50">
+					{drivers && driversTiming && (
+						<AnimatePresence mode="popLayout">
+							{Object.values(driversTiming.Lines)
+								.sort(sortPos)
+								.map((timingDriver, index) => {
+									const driver = drivers[timingDriver.RacingNumber];
+									const appTiming = appDriversTiming?.Lines[timingDriver.RacingNumber];
+
+									return (
+										<motion.div
+											key={`outing.row.${timingDriver.RacingNumber}`}
+											layout
+											initial={{ opacity: 0 }}
+											animate={{ opacity: 1 }}
+											exit={{ opacity: 0 }}
+											className={clsx("grid items-center gap-4 px-4 py-3 transition-colors hover:bg-zinc-900/40", {
+												"bg-black": oledMode,
+												"bg-zinc-950/20": !oledMode,
+											})}
+											style={{ gridTemplateColumns: "7rem 1fr" }}
+										>
+											<DriverTag
+												className="min-w-full!"
+												short={driver.Tla}
+												teamColor={driver.TeamColour}
+												position={index + 1}
+											/>
+											<div className="no-scrollbar overflow-x-auto">
+												<DriverHistoryTires stints={appTiming?.Stints} />
+											</div>
+										</motion.div>
+									);
+								})}
+						</AnimatePresence>
+					)}
+				</div>
+			</LayoutGroup>
+		</div>
+	);
+}
+
+function SkeletonRow() {
+	return (
+		<div className="grid items-center gap-4 border-b border-zinc-800/30 px-4 py-3" style={{ gridTemplateColumns: "7rem 1fr" }}>
+			<div className="h-10 animate-pulse rounded-lg bg-zinc-800" />
+			<div className="flex gap-3">
+				{[1, 2, 3].map((i) => (
+					<div key={i} className="flex flex-col items-center gap-2">
+						<div className="h-8 w-8 animate-pulse rounded-full bg-zinc-800" />
+						<div className="h-3 w-6 animate-pulse rounded bg-zinc-800" />
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/dashboard/src/components/driver/DriverHistoryTires.tsx
+++ b/dashboard/src/components/driver/DriverHistoryTires.tsx
@@ -26,7 +26,7 @@ export default function DriverHistoryTires({ stints }: Props) {
 						)}
 
 						<p className="whitespace-nowrap text-sm font-medium leading-none text-zinc-400">
-							{stint.TotalLaps}L{stint.New === "FALSE" ? "*" : ""}
+							{stint.TotalLaps}L{stint.New !== "TRUE" ? "*" : ""}
 						</p>
 					</div>
 				))}

--- a/dashboard/src/components/driver/DriverHistoryTires.tsx
+++ b/dashboard/src/components/driver/DriverHistoryTires.tsx
@@ -14,7 +14,7 @@ export default function DriverHistoryTires({ stints }: Props) {
 		<div className="flex flex-row items-center justify-start gap-1">
 			{stints &&
 				stints.map((stint, i) => (
-					<div className="flex flex-col items-center gap-1" key={`driver.${i}`}>
+					<div className="flex flex-col items-center gap-1" key={`driver.stint.${i}`}>
 						{unknownCompound(stint) && <Image src={"/tires/unknown.svg"} width={32} height={32} alt="unknown" />}
 						{!unknownCompound(stint) && stint.Compound && (
 							<Image
@@ -25,7 +25,9 @@ export default function DriverHistoryTires({ stints }: Props) {
 							/>
 						)}
 
-						<p className="text-sm leading-none font-medium whitespace-nowrap text-zinc-600">{stint.TotalLaps}L</p>
+						<p className="whitespace-nowrap text-sm font-medium leading-none text-zinc-400">
+							{stint.TotalLaps}L{stint.New === "FALSE" ? "*" : ""}
+						</p>
 					</div>
 				))}
 

--- a/dashboard/src/components/driver/DriverTire.tsx
+++ b/dashboard/src/components/driver/DriverTire.tsx
@@ -35,7 +35,7 @@ export default function DriverTire({ stints }: Props) {
 			<div>
 				<p className="leading-none font-medium">
 					L {currentStint?.TotalLaps ?? 0}
-					{currentStint?.New ? "" : "*"}
+					{currentStint?.New === "TRUE" ? "" : "*"}
 				</p>
 
 				<p className="text-sm leading-none text-zinc-500">PIT {stops}</p>

--- a/dashboard/src/types/state.type.ts
+++ b/dashboard/src/types/state.type.ts
@@ -57,7 +57,7 @@ export type TimingAppDataDriver = {
 export type Stint = {
 	TotalLaps?: number;
 	Compound?: "SOFT" | "MEDIUM" | "HARD" | "INTERMEDIATE" | "WET";
-	New?: string; // TRUE | FALSE
+	New?: "TRUE" | "FALSE";
 };
 
 export type WeatherData = {

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
implementing feature from issue #293 

- implement `OutingTable` component for session-wide tire history
- create dedicated `/dashboard/tires` page
- enhance `DriverHistoryTires` with stint progression and used set markers
- integrate "Tires" link into sidebar navigation
- update help documentation with tire history details