### PR TITLE
fix: improve regex for ical SUMMARY parsing

### DIFF
--- a/api/src/endpoints/schedule.rs
+++ b/api/src/endpoints/schedule.rs
@@ -86,7 +86,7 @@ fn find_round_mut<'a>(rounds: &'a mut Vec<Round>, name: &str) -> Option<&'a mut 
 }
 
 fn parse_name(full_name: &str) -> Option<(String, String)> {
-    let regex = Regex::new(r"FORMULA 1 (?P<name>.+) - (?P<kind>.+)").ok()?;
+    let regex = Regex::new(r"FORMULA 1 (?P<name>.+?\d{4})\s*(?:-|\u2013)\s*(?P<kind>.+)").ok()?;
     let captures = regex.captures(full_name)?;
     Some((captures["name"].to_owned(), captures["kind"].to_owned()))
 }


### PR DESCRIPTION
## Motivation
Currently, the live app fails to parse the Spanish Grand Prix sessions (e.g., "BARCELONA-CATALUNYA 2026"), leaving most of the schedule empty with only Qualifying visible.

## Problem
The issue stems from strict regex matching on the `SUMMARY` field. It appears the underlying `ical` parser struggles at some point. I verified this by running the same `.ics` file through a Go-based parser (`arran4/golang-ical`), which successfully preserved the string formatting.

The discrepancy in the `SUMMARY` field:

- **Rust (Current):**
```
"🏎 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026- Practice 1"
"🏎 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026- Practice 2"
"🏎 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026- Practice 3"
"⏱\u{fe0f} FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026 - Qualifying"
"🏁 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026- Race"
```
- **Go (Reference):**
```
"🏎 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026 - Practice 1"
"🏎 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026 - Practice 2"
"🏎 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026 - Practice 3"
"⏱️ FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026 - Qualifying"
"🏁 FORMULA 1 MSC CRUISES GRAN PREMIO DE BARCELONA-CATALUNYA 2026 - Race"
```
*Note: The Go output preserves the whitespace that the Rust parser is currently stripping.*

## The Fix
I updated the regex to be more resilient to varied whitespace and dash types:
- **Anchoring:** Added `\d{4}` to anchor the search to the year, preventing breakage on hyphenated track names.
- **Resilience:** Updated the hyphen capture to `\s*(?:-|\u2013)\s*`. This accepts both standard hyphens and the en-dash ("–") often introduced by calendar auto-formatting, while using the Unicode hex code "\u2013" to ensure source code cleanliness and avoid linting warnings.

**New Regex:**
`r"FORMULA 1 (?P<name>.+?\d{4})\s*(?:-|\u2013)\s*(?P<kind>.+)"`

## Verification
I have verified this locally against the current schedule. It successfully restores the missing Spain sessions without introducing regressions in other  sessions/ weekends (verified via output comparison).

## Note
I am not primarily a Rust developer, but I have fully tested this fix locally. This implementation should resolve the issue effectively. Feel free to use this as-is, or as a reference if you prefer to implement a deeper fix upstream in the `ical` parser crate.