### PR TITLE
fix(signalr): don't panic on non-feed SignalR Core frames

### DIFF
--- a/signalr/src/lib.rs
+++ b/signalr/src/lib.rs
@@ -200,40 +200,37 @@ pub async fn subscribe(
 
     debug!("subscribe invocation sent, waiting for completion...");
 
-    let response = client
-        .stream
-        .next()
-        .await
-        .ok_or_else(|| anyhow::anyhow!("No response received from server"))??;
+    // The Completion for our Subscribe invocation may not be the very next frame:
+    // SignalR Core can send ping/other frames first. Read until we find the
+    // Completion whose invocation id matches ours, skipping everything else.
+    loop {
+        let response = client
+            .stream
+            .next()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("No response received from server"))??;
 
-    let Message::Text(txt) = response else {
-        return Err(anyhow::anyhow!("Unexpected message type: {:?}", response));
-    };
+        let Message::Text(txt) = response else {
+            continue;
+        };
 
-    let completion = deserialize::<Completion>(&txt)?;
+        for msg in split_messages(&txt) {
+            let Ok(completion) = deserialize::<Completion>(msg) else {
+                continue;
+            };
 
-    if completion.r#type != COMPLETION {
-        return Err(anyhow::anyhow!(
-            "Unexpected message type: {}",
-            completion.r#type
-        ));
-    };
+            if completion.r#type != COMPLETION || completion.invocation_id != invocation_id {
+                continue;
+            }
 
-    if completion.invocation_id != invocation_id {
-        return Err(anyhow::anyhow!(
-            "Unexpected invocation id: {}",
-            completion.invocation_id
-        ));
-    }
+            if let Some(error) = completion.error {
+                return Err(anyhow::anyhow!("Server error: {}", error));
+            }
 
-    if let Some(error) = completion.error {
-        return Err(anyhow::anyhow!("Server error: {}", error));
-    }
-
-    if let Some(result) = completion.result {
-        return Ok(result);
-    } else {
-        return Err(anyhow::anyhow!("No result received"));
+            return completion
+                .result
+                .ok_or_else(|| anyhow::anyhow!("No result received"));
+        }
     }
 }
 
@@ -279,7 +276,16 @@ pub fn listen(client: SignalrClient) -> impl Stream<Item = Vec<UpdateArgs>> {
             let mut results = Vec::new();
 
             for msg in messages {
-                let invocation = deserialize::<FeedMessage>(&msg).unwrap();
+                // SignalR Core interleaves non-feed frames (ping `{"type":6}`,
+                // completion, close) that don't match FeedMessage's shape. Skip them
+                // instead of unwrapping into a panic that kills the ingest task.
+                let invocation = match deserialize::<FeedMessage>(msg) {
+                    Ok(invocation) => invocation,
+                    Err(err) => {
+                        debug!(?err, frame = msg, "skipping non-feed signalr frame");
+                        continue;
+                    }
+                };
 
                 if invocation.r#type != INVOCATION || invocation.target != "feed" {
                     continue;

--- a/signalr/src/lib.rs
+++ b/signalr/src/lib.rs
@@ -200,9 +200,6 @@ pub async fn subscribe(
 
     debug!("subscribe invocation sent, waiting for completion...");
 
-    // The Completion for our Subscribe invocation may not be the very next frame:
-    // SignalR Core can send ping/other frames first. Read until we find the
-    // Completion whose invocation id matches ours, skipping everything else.
     loop {
         let response = client
             .stream
@@ -276,9 +273,6 @@ pub fn listen(client: SignalrClient) -> impl Stream<Item = Vec<UpdateArgs>> {
             let mut results = Vec::new();
 
             for msg in messages {
-                // SignalR Core interleaves non-feed frames (ping `{"type":6}`,
-                // completion, close) that don't match FeedMessage's shape. Skip them
-                // instead of unwrapping into a panic that kills the ingest task.
                 let invocation = match deserialize::<FeedMessage>(msg) {
                     Ok(invocation) => invocation,
                     Err(err) => {


### PR DESCRIPTION
## Problem

After F1's live timing moved to the SignalR Core endpoint (`livetiming.formula1.com/signalrcore`), the `realtime` service crashes its ingest task within ~15s of connecting, on every published image I tested (4.0.4, 4.0.5, `develop`, and `latest` rebuilt after the recent `fix: invocation_id missing` commit). The HTTP/SSE server keeps running, so the dashboard loads but shows **no live data** — the failure is silent.

```
thread 'tokio-rt-worker' panicked at signalr/src/lib.rs:282:
called `Result::unwrap()` on an `Err` value:
Error("missing field `target`", line: 1, column: 10)
```

## Root cause

SignalR Core interleaves protocol frames among the `feed` invocations — most commonly **ping** frames `{"type":6}` (exactly the 10-char message in the panic above), plus completion/close frames. Two places assume a stricter frame shape:

1. `listen()` `.unwrap()`s **every** frame into `FeedMessage`, which requires a `target` field. The first ping panics the worker and kills all live data.
2. `subscribe()` assumes the **immediate next** frame after the Subscribe invocation is the Completion, so a ping arriving first breaks subscription.

## Fix

- `listen()`: skip frames that don't deserialize as a feed invocation instead of unwrapping (logged at `debug`).
- `subscribe()`: read until the Completion whose `invocationId` matches ours, skipping ping/other frames that may arrive first.

No protocol or struct changes — purely defensive parsing.

## Validation

Built from this branch and run against the live endpoint during an active session:

- Connects to `wss://livetiming.formula1.com/signalrcore`, handshake + subscribe succeed.
- **0 panics / 0 restarts** over a full session (vs. crash within ~15s before).
- `/api/current` serves real session state (full 44-driver list, weather, timing, `ExtrapolatedClock`/`Heartbeat`).
- Ping frames now logged as `skipping non-feed signalr frame` at debug and ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)