### PR TITLE
fix: display correct post-time penalty ordinal position

### DIFF
--- a/dashboard/src/components/dashboard/DriverViolations.tsx
+++ b/dashboard/src/components/dashboard/DriverViolations.tsx
@@ -1,6 +1,7 @@
 import type { Driver, TimingData } from "@/types/state.type";
 
 import { calculatePosition } from "@/lib/calculatePosition";
+import { toOrdinal } from "@/lib/toOrdinal";
 
 import DriverTag from "@/components/driver/DriverTag";
 
@@ -22,8 +23,10 @@ export default function DriverViolations({ driver, driverViolations, driversTimi
 				</p>
 				{driverViolations > 4 && driversTiming && (
 					<p>
-						{calculatePosition(Math.round(driverViolations / 5) * 5, driver.RacingNumber, driversTiming)}
-						th after penalty
+						{toOrdinal(
+							calculatePosition(Math.round(driverViolations / 5) * 5, driver.RacingNumber, driversTiming) ?? 0,
+						)}{" "}
+						after penalty
 					</p>
 				)}
 			</div>

--- a/dashboard/src/lib/toOrdinal.ts
+++ b/dashboard/src/lib/toOrdinal.ts
@@ -1,7 +1,5 @@
 export const toOrdinal = (position: number) => {
-	const n = position % 10;
-
-	switch (n) {
+	switch (position % 10) {
 		case 1:
 			return `${position}st`;
 		case 2:

--- a/dashboard/src/lib/toOrdinal.ts
+++ b/dashboard/src/lib/toOrdinal.ts
@@ -1,0 +1,14 @@
+export const toOrdinal = (position: number) => {
+	const n = position % 10;
+
+	switch (n) {
+		case 1:
+			return `${position}st`;
+		case 2:
+			return `${position}nd`;
+		case 3:
+			return `${position}rd`;
+		default:
+			return `${position}th`;
+	}
+};


### PR DESCRIPTION
Added a helper function to format numbers as ordinal (i.e. `1st`, `2nd`, `3rd`, `4th`) and updated DriverViolations.tsx to replace hardcoded `th`.