### PR TITLE
feat: enable ARM64/AMD64 multi-platform builds and dynamic registry owner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  USER: slowlydev
+  USER: ${{ github.repository_owner }}
 
 jobs:
   build-and-push:
@@ -59,5 +59,7 @@ jobs:
           targets: ${{ matrix.image }}
           push: true
           provenance: true
+          set: |
+            *.platform=linux/amd64,linux/arm64
           files: |
             cwd://${{ steps.meta.outputs.bake-file }}


### PR DESCRIPTION
I've added  a couple of feature, to help people integrate the dashboard in their own system and build their versione to test their feature.

1. To help on testing inside the docker/kubernetes environment that everything is working fine, I've linked the pipeline USER to the repo owner so that people can run the cicd on their own github and have their own image to test.
2. Since there was no support for ARM platform, people having raspberrypi clusters, were unable to easily deploy f1 dash to their machine, I've added explicit use of the two platform linux/amd64 and linux/arm64 to the build and push pipeline

Let me know if you find it useful and if I have to make any changes